### PR TITLE
Add diff2html-cli to Command-line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [The Fuck](https://github.com/nvbn/thefuck)- Magnificent app which corrects your previous console command.
 - [tldr](https://github.com/tldr-pages/tldr)- Simplified and community-driven man pages.
+- [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Command-line tool to parse git diffs as JSON and generate pretty HTML.
 
 ## Data Manipulation
 


### PR DESCRIPTION
[diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) is an easy to use command-line tool that parses git diffs to JSON and also generates pretty HTML. 

The tool allows better code comparisons, optimized with line-by-line and side-by-side views, new and old line numbers, inserted, removed and edited lines identification, GitHub like style, code syntax highlight and line similarity matching.