### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [cmus](https://github.com/cmus/cmus) - Small, fast and powerful console music player for Unix-like operating systems.
 - [Instant-Music-Downloader](https://github.com/yask123/Instant-Music-Downloader) - Instant music downloader.
 - [itunes-remote](https://github.com/mischah/itunes-remote) - It’s about listening to music without leaving the terminal. OS X only.
-- [pianobar](http://6xq.net/pianobar/) - Pandora client.
-- [TTYtter](https://github.com/atomicules/TTYtter) - Twitter client- ([original](http://www.floodgap.com/software/ttytter/)).
+- [pianobar](https://6xq.net/pianobar/) - Pandora client.
+- [TTYtter](https://github.com/oysttyer/oysttyer) - Twitter client- ([original](http://www.floodgap.com/software/ttytter/)).
 - [quote-cli](https://github.com/riyadhalnur/quote-cli) - Get a random quote or the quote of the day in your CLI.
 
 ### Video


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/atomicules/TTYtter | https://github.com/oysttyer/oysttyer 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://6xq.net/pianobar/ | https://6xq.net/pianobar/ 
