### PR TITLE
Add share-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [google-font-installer](https://github.com/lordgiotto/google-font-installer) - Search, download, and install any Google Font on your local machine.
 - [aria2](https://github.com/tatsuhiro-t/aria2) - Lightweight multi-protocol and multi-source, cross platform download utility. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
 - [mklicense](https://github.com/cezaraugusto/mklicense) - Create a custom LICENSE file painlessly with customized info. Busy people & beginner's friendly.
+- [share-cli](https://github.com/marionebl/share-cli) - Quickly share files from command line with your local network.
 
 ### OS X
 


### PR DESCRIPTION
share-cli is designed to share files with people on your LAN real quick. Think of it as replacment for sharing files via USB stick. 

*  easy installation via npm
*  extremely simple usage