### PR TITLE
Add remote-share-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [aria2](https://github.com/tatsuhiro-t/aria2) - Lightweight multi-protocol and multi-source, cross platform download utility. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
 - [mklicense](https://github.com/cezaraugusto/mklicense) - Create a custom LICENSE file painlessly with customized info. Busy people & beginner's friendly.
 - [share-cli](https://github.com/marionebl/share-cli) - Quickly share files from command line with your local network.
+- [remote-share-cli](https://github.com/marionebl/remote-share-cli) - Quickly share files from your command line with the world.
 
 ### OS X
 


### PR DESCRIPTION
remote-share-cli is designed to share files with people via the web real quick. 

It starts a local http server streaming the contents of exactly one file and exposes the server via `localtunnel.me`.