### PR TITLE
Add DraftLog to the list of Command-line utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Some fine resources to write your own CLI App.
 - [log-symbols](https://github.com/sindresorhus/log-symbols) - Colored symbols to differentiate output messages with a blink of an eye.
 - [log-update](https://github.com/sindresorhus/log-update) – Useful for ASCII animation. For example loading indicators.
 - [listr](https://github.com/samverschueren/listr) - Terminal task list.
+- [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 
 ### String Manipulation
 


### PR DESCRIPTION
This might look the existing `log-update`, but it's more simple and accepts multiple updates concurrently.

The Gif says what it does, and the docs even more: [https://github.com/ivanseidel/node-draftlog](https://github.com/ivanseidel/node-draftlog)

![DraftLog GIF](https://github.com/ivanseidel/node-draftlog/raw/master/midia/draftlog.gif)