### PR TITLE
Add Moro, the time tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [terjira](https://github.com/keepcosmos/terjira) - Command line power tool for Jira
 - [g3l](https://g3l.download) - Git is easy, github cli is easy but g3l easiest git cli in the w0rld!
 - [uber-cli](https://github.com/jaebradley/uber-cli) - Uber, at your fingertips.
+- [moro](https://github.com/omidfi/moro) - Time Tracker with a single command
 
 ## Utilities
 


### PR DESCRIPTION
Moro is a simple time tracker, that has only one command: moro. It's perfect for nine to five jobs with flexible hours. If you can read german, this magazine has written a nice article about it: t3n [link](http://t3n.de/news/kommandozeile-terminal-time-tracking-zeiterfassung-803805/)
I started it for my own use, but after the article got published I guessed it might be useful for others too.