### PR TITLE
Add googler

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [g3l](https://g3l.download) - Git is easy, github cli is easy but g3l easiest git cli in the w0rld!
 - [uber-cli](https://github.com/jaebradley/uber-cli) - Uber, at your fingertips.
 - [moro](https://github.com/omidfi/moro) - Time Tracker with a single command
+- [googler](https://github.com/jarun/googler) - Google Search, Google Site Search, Google News from the terminal
 
 ## Utilities
 


### PR DESCRIPTION
googler is a power tool to Google (Web & News) and Google Site Search from the command-line.
Features:

- Google Search, Google Site Search, Google News
- Fast and clean (no ads, stray URLs or clutter), custom color
- Navigate result pages from omniprompt, open URLs in browser
- Effortless keyword-based site search with googler @t add-on
- Fetch n results in a go, start at the n<sup>th</sup> result
- Disable automatic spelling correction and search exact keywords
- Specify duration, country/domain (default: worldwide/.com), language
- Google keywords (e.g. `filetype:mime`, `site:somesite.com`) support
- Open the first result directly in browser (as in *I'm Feeling Lucky*)
- Non-stop searches: fire new searches at omniprompt without exiting
- HTTPS proxy, User Agent, TLS 1.2 (default) support
- Man page with examples, completion scripts for Bash, Zsh and Fish
- Minimal dependencies