### PR TITLE
Add google-wifi-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [weather-cli](https://github.com/riyadhalnur/weather-cli) - Check the weather for your city from your terminal.
 - [hget](https://github.com/bevacqua/hget) - Render websites in plain text from your terminal.
 - [ponysay](https://github.com/erkin/ponysay) - Pony rewrite of cowsay.
+- [google-wifi-status](https://github.com/joelgeorgev/google-wifi-status) - A Node.js CLI app that displays status of your Google Wifi / OnHub router.
 
 ## Other Awesome Lists
 


### PR DESCRIPTION
A Node.js CLI app that displays status of your Google Wifi / OnHub router. https://www.npmjs.com/package/google-wifi-status